### PR TITLE
spelling + removed note on Saturn ODEs (now works as is).

### DIFF
--- a/BlueRetro-System-Specific-User-Manual.md
+++ b/BlueRetro-System-Specific-User-Manual.md
@@ -294,12 +294,6 @@ See [BlueRetro mapping reference](https://docs.google.com/spreadsheets/d/e/2PACX
 ### Special buttons functions
 * **MT (Home)**: Toogle wired output mode between GamePad & GamePadAlt.
 
-## Notes
-
-Many ODE frontends (such as Pseudo Saturn Kai) are not compatible with Analog mode, making game selection impossible.
-* Workaround 1 : Select and launch the game with **GamePad** mode, then switch to **Analog** for play.
-* Workaround 2 : Use a standard Saturn controller for ODE navigation and game launch, then plug BlueRetro for play.
-
 # PC-FX
 
 ## Multitap Config

--- a/Home.md
+++ b/Home.md
@@ -128,7 +128,7 @@ The default mapping for the common function last button:
 * MS (Select) -> Toogle wired output mode between GamePad & GamePadAlt
 
 The default mapping for the restricted function last button
-* D-pad Up -> Facotry Reset
+* D-pad Up -> Factory Reset
 * D-pad Down -> Disable BlueRetro (Deep sleep)
 
 These default can be modified via the [advance config mapping section](https://github.com/darthcloud/BlueRetro/wiki/BlueRetro-BLE-Web-Config-User-Manual#24---mapping-config).\


### PR DESCRIPTION
If Saturn note section has to stay, I'll just add the MT button as a workaround, but it works on my machine as is. 